### PR TITLE
chore(gitignore): 로컬 프로젝트 가이드 파일 ignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local-only Claude Code settings (machine-specific permissions etc.)
 .claude/settings.local.json
 
+# Local project guide (private context, not for public exposure)
+CLAUDE.md
+
 # Claude Code session/scratch directories
 .claude/projects/
 .claude/sessions/


### PR DESCRIPTION
## 배경

작업자가 로컬에서만 사용하는 프로젝트 가이드 파일 (`CLAUDE.md`) 이 저장소에 추적되지 않도록 ignore 패턴을 추가합니다.

`CLAUDE.md` 는 작업자 개인의 로컬 컨텍스트·작업 메모를 담는 용도이며, public 저장소 정책상 추적 대상에서 제외할 필요가 있습니다.

## 변경 내용

`.gitignore` 에 아래 블록 추가:

```
# Local project guide (private context, not for public exposure)
CLAUDE.md
```

## 검토 노트

- 기존 ignore 항목은 그대로 유지
- 파일 하나만 추가하는 변경이라 동작 영향 없음

## 적용 범위

alpha 반영 후 beta, real 로 전파 예정.