### PR TITLE
docs(ko): 한글 검수 결과 반영 — 릴리스 노트 조사 앞 공백 제거

### DIFF
--- a/ko/document-ai-release-notes.md
+++ b/ko/document-ai-release-notes.md
@@ -3,8 +3,8 @@
 ### 2026. 08. 11.
 
 - API 엔드포인트 도메인 변경
-  - 신규 엔드포인트 `https://api-ocr.nhncloudservice.com` 이 추가되었습니다.
-  - 기존 엔드포인트 `https://ocr.api.nhncloudservice.com` 은 2027년 7월 31일까지 유지된 후 지원이 종료됩니다.
+  - 신규 엔드포인트 `https://api-ocr.nhncloudservice.com`이 추가되었습니다.
+  - 기존 엔드포인트 `https://ocr.api.nhncloudservice.com`은 2027년 7월 31일까지 유지된 후 지원이 종료됩니다.
   - 신규 엔드포인트로 전환하세요. 자세한 내용은 [API 가이드](./document-ai-api-guide-v1.1.md)를 참고하세요.
 - 요청 파일 최대 용량 확대
   - 요청 파일 최대 용량이 5MB에서 20MB로 확대되었습니다.

--- a/ko/document-ocr-release-notes.md
+++ b/ko/document-ocr-release-notes.md
@@ -3,8 +3,8 @@
 ## 2026. 08. 11.
 
 - API 엔드포인트 도메인 변경
-  - 신규 엔드포인트 `https://api-ocr.nhncloudservice.com` 이 추가되었습니다.
-  - 기존 엔드포인트 `https://ocr.api.nhncloudservice.com` 은 2027년 7월 31일까지 유지된 후 지원이 종료됩니다.
+  - 신규 엔드포인트 `https://api-ocr.nhncloudservice.com`이 추가되었습니다.
+  - 기존 엔드포인트 `https://ocr.api.nhncloudservice.com`은 2027년 7월 31일까지 유지된 후 지원이 종료됩니다.
   - 신규 엔드포인트로 전환하세요. 자세한 내용은 [API 가이드](./document-ocr-api-guide-v2.1.md)를 참고하세요.
 - 요청 파일 최대 용량 확대
   - 요청 파일 최대 용량이 5MB에서 20MB로 확대되었습니다.

--- a/ko/general-ocr-release-notes.md
+++ b/ko/general-ocr-release-notes.md
@@ -3,8 +3,8 @@
 ### 2026. 08. 11.
 
 - API 엔드포인트 도메인 변경
-  - 신규 엔드포인트 `https://api-ocr.nhncloudservice.com` 이 추가되었습니다.
-  - 기존 엔드포인트 `https://ocr.api.nhncloudservice.com` 은 2027년 7월 31일까지 유지된 후 지원이 종료됩니다.
+  - 신규 엔드포인트 `https://api-ocr.nhncloudservice.com`이 추가되었습니다.
+  - 기존 엔드포인트 `https://ocr.api.nhncloudservice.com`은 2027년 7월 31일까지 유지된 후 지원이 종료됩니다.
   - 신규 엔드포인트로 전환하세요. 자세한 내용은 [API 가이드](./general-ocr-api-guide-v1.1.md)를 참고하세요.
 - 요청 파일 최대 용량 확대
   - 요청 파일 최대 용량이 5MB에서 20MB로 확대되었습니다.


### PR DESCRIPTION
## 개요

2026년 8월 정기 배포 문서에 대한 한글 검수 결과를 반영합니다.

코드 표기(`` ` ``) 뒤에 붙는 조사 앞의 공백을 제거했습니다. 검수 의견 6건과 일대일로 대응합니다.

## 내용

- `ko/document-ocr-release-notes.md`
- `ko/general-ocr-release-notes.md`
- `ko/document-ai-release-notes.md`

각 파일에서 2곳씩, 총 6곳을 수정했습니다.

- `` `https://api-ocr.nhncloudservice.com` 이 추가`` → `` `https://api-ocr.nhncloudservice.com`이 추가``
- `` `https://ocr.api.nhncloudservice.com` 은 2027년`` → `` `https://ocr.api.nhncloudservice.com`은 2027년``

영어, 일본어, 중국어 문서는 해당하는 표기가 없어 변경하지 않았습니다.

## 참고

검수 의견은 8월 정기 배포 PR의 인라인 코멘트로 받았습니다.
