### PR TITLE
fix: en 릴리스 노트의 API 가이드 링크 대상 정정

### DIFF
--- a/en/document-ocr-release-notes.md
+++ b/en/document-ocr-release-notes.md
@@ -5,7 +5,7 @@
 - API endpoint domain change
   - Added the new endpoint `https://api-ocr.nhncloudservice.com`.
   - The existing endpoint `https://ocr.api.nhncloudservice.com` will be maintained until July 31, 2027, after which support will end.
-  - Switch to the new endpoint. For more information, see the [API Guide](./document-ai-api-guide-v1.1.md).
+  - Switch to the new endpoint. For more information, see the [API Guide](./document-ocr-api-guide-v2.1.md).
 - Increased the maximum request file size
   - Increased the maximum request file size from 5 MB to 20 MB.
 

--- a/en/general-ocr-release-notes.md
+++ b/en/general-ocr-release-notes.md
@@ -5,7 +5,7 @@
 - API endpoint domain change
   - Added the new endpoint `https://api-ocr.nhncloudservice.com`.
   - The existing endpoint `https://ocr.api.nhncloudservice.com` will be maintained until July 31, 2027, after which support will end.
-  - Switch to the new endpoint. For more information, see the [API Guide](./document-ai-api-guide-v1.1.md).
+  - Switch to the new endpoint. For more information, see the [API Guide](./general-ocr-api-guide-v1.1.md).
 - Increased the maximum request file size
   - Increased the maximum request file size from 5 MB to 20 MB.
 


### PR DESCRIPTION
## 개요

`en` 릴리스 노트 2026년 8월 항목의 API 가이드 링크가 다른 서비스의 문서를 가리키고 있어 되돌립니다.

## 내용

| 파일 | 현재 | 수정 |
| --- | --- | --- |
| `en/document-ocr-release-notes.md` | `./document-ai-api-guide-v1.1.md` | `./document-ocr-api-guide-v2.1.md` |
| `en/general-ocr-release-notes.md` | `./document-ai-api-guide-v1.1.md` | `./general-ocr-api-guide-v1.1.md` |

`ko`, `ja`, `zh` 는 각 서비스의 가이드를 그대로 가리키고 있어 변경하지 않았습니다. `en/document-ai-release-notes.md` 도 원래 대상이 맞아 손대지 않았습니다.

가리키는 파일이 실제로 존재해서 링크가 깨지지는 않지만, 독자가 다른 서비스의 가이드로 이동합니다.

## 참고

문구 자체는 검토 결과를 그대로 유지했습니다. 링크 경로만 되돌립니다.
