### PR TITLE
docs: 오류 코드 표에 4041007 URL_NOT_FOUND 추가

### DIFF
--- a/en/document-ai-error-code.md
+++ b/en/document-ai-error-code.md
@@ -23,6 +23,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                  | Unauthorized role.                                                        |
 | 4010006    | INVALID_TOKEN                      | Invalid token.                                                            |
 | 4010007    | PERMISSION_DENIED                  | Permission denied.                                                        |
+| 4041007    | URL_NOT_FOUND                      | URL Not Found                                                             |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED           | Request size is larger than permissible limit.                            |
 | 5000001    | INTERNAL_API_FAIL                  | Internal Api fail.                                                        |
 | 5000002    | ERROR_PARSING_FAIL                 | Error parsing fail.                                                       |

--- a/en/document-ocr-error-code.md
+++ b/en/document-ocr-error-code.md
@@ -37,6 +37,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                         | Unauthorized role.                                                                         |
 | 4010006    | INVALID_TOKEN                             | Invalid token.                                                                             |
 | 4010007    | PERMISSION_DENIED                         | Permission denied.                                                                         |
+| 4041007    | URL_NOT_FOUND                             | URL Not Found                                                                              |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED                  | Request size is larger than permissible limit.                                             |
 | 5000001    | INTERNAL_API_FAIL                         | Internal Api fail.                                                                         |
 | 5000002    | ERROR_PARSING_FAIL                        | Error parsing fail.                                                                        |

--- a/en/general-ocr-error-code.md
+++ b/en/general-ocr-error-code.md
@@ -26,6 +26,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                   | Unauthorized role.                                                        |
 | 4010006    | INVALID_TOKEN                       | Invalid token.                                                            |
 | 4010007    | PERMISSION_DENIED                   | Permission denied.                                                        |
+| 4041007    | URL_NOT_FOUND                       | URL Not Found                                                             |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED            | Request size is larger than permissible limit.                            |
 | 5000001    | INTERNAL_API_FAIL                   | Internal Api fail.                                                        |
 | 5000002    | ERROR_PARSING_FAIL                  | Error parsing fail.                                                       |

--- a/ja/document-ai-error-code.md
+++ b/ja/document-ai-error-code.md
@@ -23,6 +23,7 @@
 | 4010005 | UNAUTHORIZED_ROLE | Unauthorized role.                                                           |
 | 4010006 | INVALID_TOKEN | Invalid token.                                                               |
 | 4010007 | PERMISSION_DENIED | Permission denied.                                                           |
+| 4041007 | URL_NOT_FOUND     | URL Not Found                                                                |
 | 4131000 | MAX_UPLOAD_SIZE_EXCEEDED | Request size is larger than permissible limit.                               |
 | 5000001 | INTERNAL_API_FAIL | Internal Api fail.                                                           |
 | 5000002 | ERROR_PARSING_FAIL | Error parsing fail.                                                          |

--- a/ja/document-ocr-error-code.md
+++ b/ja/document-ocr-error-code.md
@@ -37,6 +37,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                         | Unauthorized role.                                                                         |
 | 4010006    | INVALID_TOKEN                             | Invalid token.                                                                             |
 | 4010007    | PERMISSION_DENIED                         | Permission denied.                                                                         |
+| 4041007    | URL_NOT_FOUND                             | URL Not Found                                                                              |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED                  | Request size is larger than permissible limit.                                             |
 | 5000001    | INTERNAL_API_FAIL                         | Internal Api fail.                                                                         |
 | 5000002    | ERROR_PARSING_FAIL                        | Error parsing fail.                                                                        |

--- a/ja/general-ocr-error-code.md
+++ b/ja/general-ocr-error-code.md
@@ -26,6 +26,7 @@
 | 4010005 | UNAUTHORIZED_ROLE | Unauthorized role.                                                           |
 | 4010006 | INVALID_TOKEN | Invalid token.                                                               |
 | 4010007 | PERMISSION_DENIED | Permission denied.                                                           |
+| 4041007 | URL_NOT_FOUND     | URL Not Found                                                                |
 | 4131000 | MAX_UPLOAD_SIZE_EXCEEDED | Request size is larger than permissible limit.                               |
 | 5000001 | INTERNAL_API_FAIL | Internal Api fail.                                                           |
 | 5000002 | ERROR_PARSING_FAIL | Error parsing fail.                                                          |

--- a/ko/document-ai-error-code.md
+++ b/ko/document-ai-error-code.md
@@ -23,6 +23,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                  | Unauthorized role.                                                        |
 | 4010006    | INVALID_TOKEN                      | Invalid token.                                                            |
 | 4010007    | PERMISSION_DENIED                  | Permission denied.                                                        |
+| 4041007    | URL_NOT_FOUND                      | URL Not Found                                                             |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED           | Request size is larger than permissible limit.                            |
 | 5000001    | INTERNAL_API_FAIL                  | Internal Api fail.                                                        |
 | 5000002    | ERROR_PARSING_FAIL                 | Error parsing fail.                                                       |

--- a/ko/document-ocr-error-code.md
+++ b/ko/document-ocr-error-code.md
@@ -37,6 +37,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                         | Unauthorized role.                                                                         |
 | 4010006    | INVALID_TOKEN                             | Invalid token.                                                                             |
 | 4010007    | PERMISSION_DENIED                         | Permission denied.                                                                         |
+| 4041007    | URL_NOT_FOUND                             | URL Not Found                                                                              |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED                  | Request size is larger than permissible limit.                                             |
 | 5000001    | INTERNAL_API_FAIL                         | Internal Api fail.                                                                         |
 | 5000002    | ERROR_PARSING_FAIL                        | Error parsing fail.                                                                        |

--- a/ko/general-ocr-error-code.md
+++ b/ko/general-ocr-error-code.md
@@ -26,6 +26,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                   | Unauthorized role.                                                        |
 | 4010006    | INVALID_TOKEN                       | Invalid token.                                                            |
 | 4010007    | PERMISSION_DENIED                   | Permission denied.                                                        |
+| 4041007    | URL_NOT_FOUND                       | URL Not Found                                                             |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED            | Request size is larger than permissible limit.                            |
 | 5000001    | INTERNAL_API_FAIL                   | Internal Api fail.                                                        |
 | 5000002    | ERROR_PARSING_FAIL                  | Error parsing fail.                                                       |

--- a/zh/document-ai-error-code.md
+++ b/zh/document-ai-error-code.md
@@ -23,6 +23,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                  | Unauthorized role.                                                        |
 | 4010006    | INVALID_TOKEN                      | Invalid token.                                                            |
 | 4010007    | PERMISSION_DENIED                  | Permission denied.                                                        |
+| 4041007    | URL_NOT_FOUND                      | URL Not Found                                                             |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED           | Request size is larger than permissible limit.                            |
 | 5000001    | INTERNAL_API_FAIL                  | Internal Api fail.                                                        |
 | 5000002    | ERROR_PARSING_FAIL                 | Error parsing fail.                                                       |

--- a/zh/document-ocr-error-code.md
+++ b/zh/document-ocr-error-code.md
@@ -37,6 +37,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                         | Unauthorized role.                                                                         |
 | 4010006    | INVALID_TOKEN                             | Invalid token.                                                                             |
 | 4010007    | PERMISSION_DENIED                         | Permission denied.                                                                         |
+| 4041007    | URL_NOT_FOUND                             | URL Not Found                                                                              |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED                  | Request size is larger than permissible limit.                                             |
 | 5000001    | INTERNAL_API_FAIL                         | Internal Api fail.                                                                         |
 | 5000002    | ERROR_PARSING_FAIL                        | Error parsing fail.                                                                        |

--- a/zh/general-ocr-error-code.md
+++ b/zh/general-ocr-error-code.md
@@ -26,6 +26,7 @@
 | 4010005    | UNAUTHORIZED_ROLE                   | Unauthorized role.                                                        |
 | 4010006    | INVALID_TOKEN                       | Invalid token.                                                            |
 | 4010007    | PERMISSION_DENIED                   | Permission denied.                                                        |
+| 4041007    | URL_NOT_FOUND                       | URL Not Found                                                             |
 | 4131000    | MAX_UPLOAD_SIZE_EXCEEDED            | Request size is larger than permissible limit.                            |
 | 5000001    | INTERNAL_API_FAIL                   | Internal Api fail.                                                        |
 | 5000002    | ERROR_PARSING_FAIL                  | Error parsing fail.                                                       |


### PR DESCRIPTION
## 변경 내용

오류 코드 표에 `4041007 URL_NOT_FOUND` 를 추가했습니다.

- 대상: General OCR, Document OCR, Document AI 의 오류 코드 문서 3종
- 언어: ko, en, ja, zh 4개 언어 (총 12개 파일)

## 배경

신규 API 엔드포인트 도메인에서 공개된 API 목록에 없는 경로를 호출하거나 지원하지 않는 방식으로 호출하면 HTTP 404 와 `4041007 URL Not Found` 를 반환합니다.
기존 엔드포인트와 같은 오류 응답 형식이므로, 도메인만 전환하는 경우 오류 처리를 바꿀 필요가 없습니다.

표에 이미 있는 `404 NOT_FOUND` 와 `405 METHOD_NOT_ALLOWED` 와 성격이 같아 동일한 정렬 규칙(코드 오름차순)으로 넣었습니다.

## 확인한 것

- 12개 파일 모두 `4010007` 다음 줄에 삽입하고, 표 열 폭을 각 파일의 기존 행에 맞췄습니다.
- 파일별 줄바꿈 문자를 보존했습니다. 일부 파일은 CRLF 입니다.
- `resultKey` 와 `resultMessage` 가 영어라 언어별 번역 대상이 없습니다.
