### PR TITLE
docs(en/release-notes): 영문 번역 검수 결과를 반영한다

### DIFF
--- a/en/document-ai-release-notes.md
+++ b/en/document-ai-release-notes.md
@@ -2,12 +2,12 @@
 
 ### August 11, 2026
 
-- API endpoint domain changed
-  - The new endpoint `https://api-ocr.nhncloudservice.com` has been added.
-  - The existing endpoint `https://ocr.api.nhncloudservice.com` will be supported until July 31, 2027.
-  - Please switch to the new endpoint. For more information, refer to the [API Guide](./document-ai-api-guide-v1.1.md).
-- Maximum request file size increased
-  - The maximum request file size has been increased from 5 MB to 20 MB.
+- API endpoint domain change
+  - Added the new endpoint `https://api-ocr.nhncloudservice.com`.
+  - The existing endpoint `https://ocr.api.nhncloudservice.com` will be maintained until July 31, 2027, after which support will end.
+  - Switch to the new endpoint. For more information, see the [API Guide](./document-ai-api-guide-v1.1.md).
+- Increased the maximum request file size
+  - Increased the maximum request file size from 5 MB to 20 MB.
 
 ### March 10, 2026
 

--- a/en/document-ocr-release-notes.md
+++ b/en/document-ocr-release-notes.md
@@ -2,16 +2,16 @@
 
 ### August 11, 2026
 
-- API endpoint domain changed
-  - The new endpoint `https://api-ocr.nhncloudservice.com` has been added.
-  - The existing endpoint `https://ocr.api.nhncloudservice.com` will be supported until July 31, 2027.
-  - Please switch to the new endpoint. For more information, refer to the [API Guide](./document-ocr-api-guide-v2.1.md).
-- Maximum request file size increased
-  - The maximum request file size has been increased from 5 MB to 20 MB.
+- API endpoint domain change
+  - Added the new endpoint `https://api-ocr.nhncloudservice.com`.
+  - The existing endpoint `https://ocr.api.nhncloudservice.com` will be maintained until July 31, 2027, after which support will end.
+  - Switch to the new endpoint. For more information, see the [API Guide](./document-ocr-api-guide-v2.1.md).
+- Increased the maximum request file size
+  - Increased the maximum request file size from 5 MB to 20 MB.
 
 ### May 27, 2026
 
-- Passport authenticity verification service terminated
+- Deprecated the passport authenticity verification service.
   - ID authenticity verification has been limited to resident registration card and driver's license.
   - For more information, see the [API Guide](./document-ocr-api-guide-v2.1.md).
 

--- a/en/general-ocr-release-notes.md
+++ b/en/general-ocr-release-notes.md
@@ -2,12 +2,12 @@
 
 ### August 11, 2026
 
-- API endpoint domain changed
-  - The new endpoint `https://api-ocr.nhncloudservice.com` has been added.
-  - The existing endpoint `https://ocr.api.nhncloudservice.com` will be supported until July 31, 2027.
-  - Please switch to the new endpoint. For more information, refer to the [API Guide](./general-ocr-api-guide-v1.1.md).
-- Maximum request file size increased
-  - The maximum request file size has been increased from 5 MB to 20 MB.
+- API endpoint domain change
+  - Added the new endpoint `https://api-ocr.nhncloudservice.com`.
+  - The existing endpoint `https://ocr.api.nhncloudservice.com` will be maintained until July 31, 2027, after which support will end.
+  - Switch to the new endpoint. For more information, see the [API Guide](./general-ocr-api-guide-v1.1.md).
+- Increased the maximum request file size
+  - Increased the maximum request file size from 5 MB to 20 MB.
 
 ### March 10, 2026
 


### PR DESCRIPTION
## 배경

`alpha` 와 다른 브랜치(`beta`, `release`, `master`) 사이에 영문 릴리스 노트 문구 차이가 남아 있었습니다.

8월 영문 번역 검수 결과가 `beta` 계열에만 반영되고 `alpha` 에는 들어오지 않아 생긴 차이입니다.

## 변경

번역 검수본을 `alpha` 에 반영해 문구를 일치시킵니다.

- `en/document-ai-release-notes.md`
- `en/document-ocr-release-notes.md`
- `en/general-ocr-release-notes.md`

## 확인

반영 후 `alpha` 와 `master` 의 문서 문장 차이가 없음을 확인했습니다.

```
git diff --ignore-cr-at-eol -w HEAD upstream/master -- 'ko/*' 'en/*' 'ja/*' 'zh/*'
# 표 구분선 폭을 제외한 문장 차이 없음
```
