### PR TITLE
docs(release-notes): 9월 정기 배포일을 9월 15일로 바로잡는다

### DIFF
--- a/ko/document-ocr-release-notes.md
+++ b/ko/document-ocr-release-notes.md
@@ -3,8 +3,8 @@
 <a id="ai-service-ocr-document-ocr-release-notes"></a>
 ## AI Service > OCR > Document OCR > 릴리스 노트 { #ai-service-ocr-document-ocr-release-notes }
 
-<a id="september-8-2026"></a>
-## 2026. 09. 08. { #september-8-2026 }
+<a id="september-15-2026"></a>
+## 2026. 09. 15. { #september-15-2026 }
 
 - 운전면허증 진위 확인 시 암호 일련번호 필수화
   - 2026년 9월 7일부터 운전면허증 진위 확인 요청에 암호 일련번호를 반드시 포함해야 합니다.


### PR DESCRIPTION
## 배경

9월 정기 배포일이 9월 15일입니다. 릴리스 노트 절 제목을 9월 8일로 적어 두어 실제 배포일과 어긋납니다.

## 변경 내용

- 릴리스 노트 절 제목
  - `2026. 09. 08.` 을 `2026. 09. 15.` 로 변경
  - 앵커 ID 도 함께 변경
- 본문의 적용일 `2026년 9월 7일` 은 그대로 둡니다. 배포일과 적용일이 다릅니다.

## 검토 노트

- `ko` 만 수정했습니다. `en` 과 `ja` 는 번역 Agent 가 `ko` 기준으로 생성·관리하므로 직접 수정하지 않았습니다.

## 적용 범위

| 파일 | 변경 |
| --- | --- |
| `ko/document-ocr-release-notes.md` | 절 제목과 앵커 ID |
